### PR TITLE
Allow fixed dependencies.end location

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject walmartlabs/shared-deps "0.2.6"
+(defproject clanhr/shared-deps "0.2.6"
   :description "Centralized declaration of dependencies for multi-projects"
-  :url "https://github.com/walmartlabs/shared-deps"
+  :url "https://github.com/clanhr/shared-deps"
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :eval-in-leiningen true

--- a/src/shared_deps/plugin.clj
+++ b/src/shared_deps/plugin.clj
@@ -109,6 +109,12 @@
                                     read-dependencies-file)]
     (merge sibling-dependencies shared-dependencies)))
 
+(defn- shared-dependencies
+  [project]
+  (if-let [source (:dependencies.edn project)]
+    (read-dependencies-file (:dependencies.edn project))
+    (read-shared-dependencies project)))
+
 (defn- ->id-list
   [ids]
   (->> ids
@@ -272,7 +278,7 @@
   key, and modifies the :dependencies key."
   [project]
   (let [profiles (->> project meta :included-profiles (filter keyword?) distinct)]
-    (if-let [shared-dependencies (read-shared-dependencies project)]
+    (if-let [shared-dependencies (shared-dependencies project)]
       (do
         (main/debug (format
                       "Adding shared dependencies for project %s with profiles %s."


### PR DESCRIPTION
Thanks for this project. We already have several libs and were hurting with updates. However, we don't have a master folder with all the modules, all our structure is flat and we have several projects that depende on several common libs.

If the project file has a `dependencies.edn` key, it will be slurped and no more dependencies.edn files will be searched.
